### PR TITLE
added ability to add only website enabled products

### DIFF
--- a/src/app/code/community/Diglin/Ricento/Block/Adminhtml/Products/Listing/Edit/Tabs/Products/Add.php
+++ b/src/app/code/community/Diglin/Ricento/Block/Adminhtml/Products/Listing/Edit/Tabs/Products/Add.php
@@ -51,12 +51,16 @@ class Diglin_Ricento_Block_Adminhtml_Products_Listing_Edit_Tabs_Products_Add
         if ($this->getListing()->getId()) {
             $this->setDefaultFilter(array('in_category'=>1));
         }
+
+        $store = Mage::app()->getWebsite($this->getListing()->getWebsiteId())->getDefaultStore();
+
         /* @var $collection Mage_Catalog_Model_Resource_Product_Collection */
         $collection = Mage::getResourceModel('catalog/product_collection')
             ->addAttributeToSelect('name')
             ->addAttributeToSelect('sku')
             ->addAttributeToSelect('type_id')
             ->addWebsiteFilter($this->getListing()->getWebsiteId())
+            ->setStoreId($store->getId())
             ->addAttributeToFilter('type_id', array('in' => $this->_helper->getAllowedProductTypes()))
             ->addAttributeToFilter('status', Mage_Catalog_Model_Product_Status::STATUS_ENABLED)
             //->addFieldToFilter('visibility', array('neq' => Mage_Catalog_Model_Product_Visibility::VISIBILITY_NOT_VISIBLE ))


### PR DESCRIPTION
Hi,

this enables the user to add products to the listing which are only enabled in the associated store.
As Magento products can only get enabled or disabled for website, the website is taken from the listing and the default store id is added to the collection.

Best regards,

schnere
